### PR TITLE
Fix indexing exceptions

### DIFF
--- a/flask/explorer.py
+++ b/flask/explorer.py
@@ -110,8 +110,8 @@ def update():
         utils.log_indexing('============ INDEXING COMPLETED ============\n\n')
         utils.log('============ INDEXING COMPLETED ============\n\n')
         return success_message
-    except:
-        raise
+    except Exception as e:
+    	utils.log_indexing('[ERROR] Returning error ' + str(e) + "\n Traceback:\n" + traceback.format_exc())
 
 
 @app.route('/incrementalupdate', methods=['POST'])

--- a/flask/search.py
+++ b/flask/search.py
@@ -561,6 +561,9 @@ def create_sequence_criteria(criteria, uris):
     Returns: String containing a SPARQL filter
 
     """
+    if len(uri) == 0:
+        return ''
+
     return 'FILTER (' + ' || '.join(['?subject = <' + uri + '>' for uri in uris]) + ')'
 
 


### PR DESCRIPTION
All indexing related exceptions will now go into the indexing log. Also adds a check for an empty URI list when creating a filter.