### PR TITLE
Harden SBOLExplorer indexing and SPARQL dataset handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build the Docker image
       run: |
-          cd flask/docker
-          docker build . --file Dockerfile --tag myersresearchgroup/sbolexplorer:snapshot
-          docker build . --file Dockerfile-synbiohub --tag myersresearchgroup/sbolexplorer:snapshot-synbiohub
+          docker build flask --file flask/docker/Dockerfile-source --tag myersresearchgroup/sbolexplorer:snapshot
+          docker build flask --file flask/docker/Dockerfile-source --build-arg EXPLORER_CONFIG=docker/config-synbiohub.json --tag myersresearchgroup/sbolexplorer:snapshot-synbiohub
+          docker run --rm --entrypoint python myersresearchgroup/sbolexplorer:snapshot-synbiohub -m unittest discover -s tests
     - uses: azure/docker-login@v1
       with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/flask/docker/Dockerfile-source
+++ b/flask/docker/Dockerfile-source
@@ -1,0 +1,45 @@
+FROM ubuntu:22.04
+
+# SBOLExplorer currently vendors an x86-64 vsearch binary. Pin this image to
+# amd64 explicitly so an arm64 builder cannot produce an image that starts but
+# fails only when the first sequence search tries to execute that binary.
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=America/New_York
+
+RUN test "$(dpkg --print-architecture)" = "amd64"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates cron python3 python3-pip python3-venv tzdata \
+    && ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime \
+    && dpkg-reconfigure -f noninteractive tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN python3 -m venv /opt/sbolexplorer-venv
+ENV PATH=/opt/sbolexplorer-venv/bin:$PATH
+
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r /tmp/requirements.txt
+
+WORKDIR /SBOLExplorer/flask
+COPY . .
+
+# Build either the standalone default (`config.json`) or the SynBioHub-wired
+# variant (`docker/config-synbiohub.json`) from this exact checked-out source.
+ARG EXPLORER_CONFIG=config.json
+RUN crontab update.cron \
+    && mkdir -p /mnt/config /mnt/data \
+    && cp "$EXPLORER_CONFIG" /mnt/config/config.json \
+    && rm -rf dumps config.json \
+    && ln -s /mnt/data dumps \
+    && ln -s /mnt/config/config.json config.json
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV FLASK_APP=explorer.py
+ENV FLASK_ENV=development
+
+EXPOSE 13162
+
+CMD ["flask", "run", "--host=0.0.0.0", "--port=13162"]

--- a/flask/docker/Dockerfile-source
+++ b/flask/docker/Dockerfile-source
@@ -1,8 +1,6 @@
 FROM ubuntu:22.04
 
-# SBOLExplorer currently vendors an x86-64 vsearch binary. Pin this image to
-# amd64 explicitly so an arm64 builder cannot produce an image that starts but
-# fails only when the first sequence search tries to execute that binary.
+# The vendored vsearch executable is x86-64, so source images are amd64-only.
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=America/New_York
 

--- a/flask/explorer.py
+++ b/flask/explorer.py
@@ -69,8 +69,6 @@ def startup():
         log.error(f'Error during startup: {e}')
         raise
     
-startup()
-
 def update_index():
     logger_.log('============ STARTING INDEXING ============\n\n', True)
     config_manager.save_update_start_time()
@@ -213,6 +211,12 @@ def search_by_string():
     except Exception as e:
         log.error(f'Error during search by string: {e}')
         raise
+
+# Run startup only after every function it may call has been defined. The
+# previous module-level call appeared before update_index(), so a fresh
+# Elasticsearch volume always failed with NameError while trying to create its
+# first index.
+startup()
 
 if __name__ == "__main__":
     app.run(debug=False, threaded=True) # threaded=True

--- a/flask/explorer.py
+++ b/flask/explorer.py
@@ -212,10 +212,8 @@ def search_by_string():
         log.error(f'Error during search by string: {e}')
         raise
 
-# Run startup only after every function it may call has been defined. The
-# previous module-level call appeared before update_index(), so a fresh
-# Elasticsearch volume always failed with NameError while trying to create its
-# first index.
+# Initialize Explorer after all startup dependencies, including update_index,
+# have been defined.
 startup()
 
 if __name__ == "__main__":

--- a/flask/query.py
+++ b/flask/query.py
@@ -219,11 +219,8 @@ def send_query(query, endpoint):
 
     Returns: List of parts from Virtuoso
     """
-    # Index maintenance intentionally scans all named graphs. Sending an empty
-    # `default-graph-uri=` happens to be ignored by Virtuoso, but protocol-
-    # compliant stores treat it as an explicit empty dataset and correctly
-    # return no rows. Omit the parameter to request the store's union default;
-    # scoped user searches still carry explicit FROM clauses in their query.
+    # Index maintenance queries use the endpoint's complete dataset. Searches
+    # that require a narrower dataset express it with FROM clauses in SPARQL.
     params = {'query': query}
 
     url = f"{endpoint}{urllib.parse.urlencode(params)}"

--- a/flask/query.py
+++ b/flask/query.py
@@ -219,10 +219,12 @@ def send_query(query, endpoint):
 
     Returns: List of parts from Virtuoso
     """
+    # Index maintenance intentionally scans all named graphs. Sending an empty
+    # `default-graph-uri=` happens to be ignored by Virtuoso, but protocol-
+    # compliant stores treat it as an explicit empty dataset and correctly
+    # return no rows. Omit the parameter to request the store's union default;
+    # scoped user searches still carry explicit FROM clauses in their query.
     params = {'query': query}
-
-    if endpoint == config['sparql_endpoint']:
-        params['default-graph-uri'] = ''  # Modify this if needed
 
     url = f"{endpoint}{urllib.parse.urlencode(params)}"
     headers = {'Accept': 'application/json'}

--- a/flask/search.py
+++ b/flask/search.py
@@ -183,11 +183,9 @@ def search_es_allowed_subjects_empty_string(allowed_subjects: List[str]):
         logger_.log("search_es_allowed_subjects_empty_string")
         raise
 def parse_sparql_query(sparql_query, is_count_query):
-    # Search visibility is encoded in dataset clauses before the first WHERE.
-    # The old row-query regex assumed `?type` was the final projected field,
-    # so it stopped recognizing FROM clauses when SynBioHub added `?sbolType`
-    # and `?role`. Extract the clauses themselves instead of depending on the
-    # projection layout; this works for both row and nested count templates.
+    # Search visibility is encoded by every FROM clause before the first WHERE.
+    # Dataset extraction is independent of the SELECT projection and shared by
+    # row and nested count templates.
     query_head = re.split(r'\bWHERE\b', sparql_query, maxsplit=1, flags=re.IGNORECASE)[0]
     _from = ' '.join(FROM_CLAUSE_PATTERN.findall(query_head))
 

--- a/flask/search.py
+++ b/flask/search.py
@@ -13,8 +13,7 @@ logger_ = Logger()
 wor_client_ = WORClient()
 
 # Compile regex patterns
-FROM_COUNT_PATTERN = re.compile(r'SELECT \(count\(distinct \?subject\) as \?tempcount\)\s*(.*)\s*WHERE {')
-FROM_NORMAL_PATTERN = re.compile(r'\?type\n(.*)\s*WHERE {')
+FROM_CLAUSE_PATTERN = re.compile(r'FROM\s+<[^>]+>', re.IGNORECASE)
 CRITERIA_PATTERN = re.compile(r'WHERE {\s*(.*)\s*\?subject a \?type \.')
 OFFSET_PATTERN = re.compile(r'OFFSET (\d+)')
 LIMIT_PATTERN = re.compile(r'LIMIT (\d+)')
@@ -184,9 +183,13 @@ def search_es_allowed_subjects_empty_string(allowed_subjects: List[str]):
         logger_.log("search_es_allowed_subjects_empty_string")
         raise
 def parse_sparql_query(sparql_query, is_count_query):
-    # Find FROM clause
-    _from_search = FROM_COUNT_PATTERN.search(sparql_query) if is_count_query else FROM_NORMAL_PATTERN.search(sparql_query)
-    _from = _from_search.group(1).strip() if _from_search else ''
+    # Search visibility is encoded in dataset clauses before the first WHERE.
+    # The old row-query regex assumed `?type` was the final projected field,
+    # so it stopped recognizing FROM clauses when SynBioHub added `?sbolType`
+    # and `?role`. Extract the clauses themselves instead of depending on the
+    # projection layout; this works for both row and nested count templates.
+    query_head = re.split(r'\bWHERE\b', sparql_query, maxsplit=1, flags=re.IGNORECASE)[0]
+    _from = ' '.join(FROM_CLAUSE_PATTERN.findall(query_head))
 
     # Find criteria
     criteria_search = CRITERIA_PATTERN.search(sparql_query)

--- a/flask/tests/test_query.py
+++ b/flask/tests/test_query.py
@@ -1,0 +1,90 @@
+import ast
+from pathlib import Path
+import unittest
+from unittest import mock
+from urllib.parse import parse_qs, urlsplit
+
+import query
+import search
+
+
+class QueryProtocolTests(unittest.TestCase):
+    @mock.patch("query.requests.get")
+    def test_union_index_query_omits_empty_default_graph(self, get):
+        response = mock.Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {"results": {"bindings": []}}
+        get.return_value = response
+
+        query.send_query("SELECT ?s WHERE { ?s ?p ?o }", query.config["sparql_endpoint"])
+
+        requested_url = get.call_args.args[0]
+        parameters = parse_qs(urlsplit(requested_url).query, keep_blank_values=True)
+        self.assertIn("query", parameters)
+        self.assertNotIn("default-graph-uri", parameters)
+
+
+class SearchDatasetTests(unittest.TestCase):
+    def test_row_query_extracts_graphs_after_extended_projection(self):
+        sparql = """
+            SELECT DISTINCT
+                ?subject
+                ?type
+                ?sbolType
+                ?role
+            FROM <http://example.test/public>
+            FROM <http://example.test/user/alice>
+            WHERE {
+                ?subject a ?type .
+                ?subject sbh:topLevel ?subject .
+            }
+            LIMIT 50
+            OFFSET 0
+        """
+
+        _, from_clause, _, _, _, _, _ = search.extract_query(sparql)
+
+        self.assertEqual(
+            from_clause,
+            "FROM <http://example.test/public> FROM <http://example.test/user/alice>",
+        )
+
+    def test_count_query_extracts_outer_graphs(self):
+        sparql = """
+            SELECT (sum(?tempcount) as ?count)
+            FROM <http://example.test/user/alice>
+            WHERE {
+                {
+                    SELECT (count(distinct ?subject) as ?tempcount)
+                    WHERE { ?subject a ?type . }
+                }
+            }
+        """
+
+        _, from_clause, _, _, _, _, _ = search.extract_query(sparql)
+
+        self.assertEqual(from_clause, "FROM <http://example.test/user/alice>")
+
+
+class StartupOrderTests(unittest.TestCase):
+    def test_update_index_is_defined_before_startup_is_called(self):
+        source = Path(__file__).parents[1] / "explorer.py"
+        module = ast.parse(source.read_text())
+        update_definition = next(
+            node.lineno
+            for node in module.body
+            if isinstance(node, ast.FunctionDef) and node.name == "update_index"
+        )
+        startup_call = next(
+            node.lineno
+            for node in module.body
+            if isinstance(node, ast.Expr)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id == "startup"
+        )
+        self.assertLess(update_definition, startup_call)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR makes SBOLExplorer indexing more deterministic and portable across SPARQL stores. Explorer initialization occurs only after the index-update functions are defined, allowing fresh deployments to build their first index reliably. Index maintenance queries operate over the endpoint’s complete dataset without sending an empty default-graph-uri, while search queries extract explicit FROM clauses independently of the SELECT projection for both result and count queries. CI now builds SBOLExplorer directly from the checked-out source and runs focused tests covering startup ordering, query transport, and dataset scoping.